### PR TITLE
Restore stack trace logging

### DIFF
--- a/v1/callstack.go
+++ b/v1/callstack.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -20,6 +21,7 @@ type frameInfo struct {
 	filename     string
 	lineno       int
 	method       string
+	pc           uintptr
 	context      []*sourceLine
 	contextLines int
 }
@@ -145,117 +147,53 @@ func (ci *frameInfo) String(color string, sourceColor string) string {
 	return buf.String()
 }
 
-// parseDebugStack parases a stack created by debug.Stack()
-//
-// This is what the string looks like
-// /Users/mgutz/go/src/github.com/mgutz/logxi/v1/jsonFormatter.go:45 (0x5fa70)
-// 	(*JSONFormatter).writeError: jf.writeString(buf, err.Error()+"\n"+string(debug.Stack()))
-// /Users/mgutz/go/src/github.com/mgutz/logxi/v1/jsonFormatter.go:82 (0x5fdc3)
-// 	(*JSONFormatter).appendValue: jf.writeError(buf, err)
-// /Users/mgutz/go/src/github.com/mgutz/logxi/v1/jsonFormatter.go:109 (0x605ca)
-// 	(*JSONFormatter).set: jf.appendValue(buf, val)
-// ...
-// /Users/mgutz/goroot/src/runtime/asm_amd64.s:2232 (0x38bf1)
-// 	goexit:
-func parseDebugStack(stack string, skip int, ignoreRuntime bool) []*frameInfo {
+// Generates a stack from runtime.Callers()
+func stackFrames(skip int, ignoreRuntime bool) []*frameInfo {
 	frames := []*frameInfo{}
-	// BUG temporarily disable since there is a bug with embedded newlines
-	if true {
-		return frames
-	}
+	size := 20
+	pcs := make([]uintptr, size)
+	// always skip the first frame, since it's runtime.Callers itself
+	pcs = pcs[:runtime.Callers(1+skip, pcs)]
 
-	lines := strings.Split(stack, "\n")
-
-	for i := skip * 2; i < len(lines); i += 2 {
-		ci := &frameInfo{}
-		sourceLine := lines[i]
-		if sourceLine == "" {
-			break
-		}
-		if ignoreRuntime && strings.Contains(sourceLine, filepath.Join("src", "runtime")) {
+	for _, pc := range pcs {
+		fn := runtime.FuncForPC(pc)
+		name := fn.Name()
+		file, line := fn.FileLine(pc - 1)
+		if ignoreRuntime && strings.Contains(file, filepath.Join("src", "runtime")) {
 			break
 		}
 
-		colon := strings.Index(sourceLine, ":")
-		slash := strings.Index(sourceLine, "/")
-		if colon < slash {
-			// must be on Windows where paths look like c:/foo/bar.go:lineno
-			colon = strings.Index(sourceLine[slash:], ":") + slash
+		ci := &frameInfo{
+			filename: file,
+			lineno:   line,
+			method:   name,
+			pc:       pc,
 		}
-		space := strings.Index(sourceLine, " ")
-		ci.filename = sourceLine[0:colon]
 
-		// BUG with callstack where the error message has embedded newlines
-		// if colon > space {
-		// 	fmt.Println("lines", lines)
-		// }
-		// fmt.Println("SOURCELINE", sourceLine, "len", len(sourceLine), "COLON", colon, "SPACE", space)
-		numstr := sourceLine[colon+1 : space]
-		lineno, err := strconv.Atoi(numstr)
-		if err != nil {
-			InternalLog.Warn("Could not parse line number", "sourceLine", sourceLine, "numstr", numstr)
-			continue
-		}
-		ci.lineno = lineno
-
-		methodLine := lines[i+1]
-		colon = strings.Index(methodLine, ":")
-		ci.method = strings.Trim(methodLine[0:colon], "\t ")
 		frames = append(frames, ci)
 	}
 	return frames
 }
 
-// parseDebugStack parases a stack created by debug.Stack()
-//
-// This is what the string looks like
-// /Users/mgutz/go/src/github.com/mgutz/logxi/v1/jsonFormatter.go:45 (0x5fa70)
-// 	(*JSONFormatter).writeError: jf.writeString(buf, err.Error()+"\n"+string(debug.Stack()))
-// /Users/mgutz/go/src/github.com/mgutz/logxi/v1/jsonFormatter.go:82 (0x5fdc3)
-// 	(*JSONFormatter).appendValue: jf.writeError(buf, err)
-// /Users/mgutz/go/src/github.com/mgutz/logxi/v1/jsonFormatter.go:109 (0x605ca)
-// 	(*JSONFormatter).set: jf.appendValue(buf, val)
-// ...
-// /Users/mgutz/goroot/src/runtime/asm_amd64.s:2232 (0x38bf1)
-// 	goexit:
-func trimDebugStack(stack string) string {
+// Returns debug stack excluding logxi frames
+func trimmedStackTrace() string {
 	buf := pool.Get()
 	defer pool.Put(buf)
-	lines := strings.Split(stack, "\n")
-	for i := 0; i < len(lines); i += 2 {
-		sourceLine := lines[i]
-		if sourceLine == "" {
-			break
-		}
-
-		colon := strings.Index(sourceLine, ":")
-		slash := strings.Index(sourceLine, "/")
-		if colon < slash {
-			// must be on Windows where paths look like c:/foo/bar.go:lineno
-			colon = strings.Index(sourceLine[slash:], ":") + slash
-		}
-		filename := sourceLine[0:colon]
+	frames := stackFrames(0, false)
+	for _, frame := range frames {
 		// skip anything in the logxi package
-		if isLogxiCode(filename) {
+		if isLogxiCode(frame.filename) {
 			continue
 		}
-		buf.WriteString(sourceLine)
-		buf.WriteRune('\n')
-		buf.WriteString(lines[i+1])
-		buf.WriteRune('\n')
+
+		fmt.Fprintf(buf, "%s:%d (0x%x)\n", frame.filename, frame.lineno, frame.pc)
+
+		err := frame.readSource(0)
+		if err != nil || len(frame.context) < 1 {
+			continue
+		}
+
+		fmt.Fprintf(buf, "\t%s: %s\n", frame.method, frame.context[0].line)
 	}
 	return buf.String()
-}
-
-func parseLogxiStack(entry map[string]interface{}, skip int, ignoreRuntime bool) []*frameInfo {
-	kv := entry[KeyMap.CallStack]
-	if kv == nil {
-		return nil
-	}
-
-	var frames []*frameInfo
-	if stack, ok := kv.(string); ok {
-		frames = parseDebugStack(stack, skip, ignoreRuntime)
-	}
-	return frames
 }

--- a/v1/happyDevFormatter.go
+++ b/v1/happyDevFormatter.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"runtime/debug"
 	"strings"
 
 	"github.com/mgutz/ansi"
@@ -175,7 +174,7 @@ func (hd *HappyDevFormatter) getContext(color string) string {
 	if disableCallstack {
 		return ""
 	}
-	frames := parseDebugStack(string(debug.Stack()), 5, true)
+	frames := stackFrames(7, true)
 	if len(frames) == 0 {
 		return ""
 	}
@@ -220,17 +219,15 @@ func (hd *HappyDevFormatter) getLevelContext(level int, entry map[string]interfa
 		}
 
 		if disableCallstack || contextLines == -1 {
-			context = trimDebugStack(string(debug.Stack()))
+			context = trimmedStackTrace()
 			break
 		}
-		frames := parseLogxiStack(entry, 4, true)
-		if frames == nil {
-			frames = parseDebugStack(string(debug.Stack()), 4, true)
-		}
 
+		frames := stackFrames(6, true)
 		if len(frames) == 0 {
 			break
 		}
+
 		errbuf := pool.Get()
 		defer pool.Put(errbuf)
 		lines := 0


### PR DESCRIPTION
Courtesy of @paulrosania

---

This patch restores stack trace logging. It avoids parsing stack trace
text, opting for runtime.Callers and runtime.FuncForPC instead.

Support for overriding the stack trace by setting KeyMap.CallStack was
removed. This only worked in happyDevFormatter, and would have triggered
a warning anyway, since it's a reserved key.