### PR TITLE
fix log level when multiple matches

### DIFF
--- a/v1/env.go
+++ b/v1/env.go
@@ -129,6 +129,7 @@ func getLogLevel(name string) int {
 	for k, v := range logxiNameLevelMap {
 		if k == name {
 			result = v
+			break
 		} else if k == "*" {
 			wildcardLevel = v
 		} else if strings.HasPrefix(k, "*") && strings.HasSuffix(name, k[1:]) {


### PR DESCRIPTION
# By @vbehar

for example if the logxiNameLevelMap contains:
- logger1:* = INF
- logger1:logger2 = DBG

because the map iteration order is not guaranteed, logger1:logger2 might be either INF or BDG

this fix gives priority to the exact match, by stopping the iteration